### PR TITLE
thoughts on nproc logic

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -59,7 +59,7 @@ process bz_to_gz {
     script:
     """
     #! /usr/bin/env bash
-    PROC=\$((`nproc`/2))
+    PROC=\$((`nproc` % 4))
     parallel -j 2 "bzcat {1} | pigz -p \${PROC} > {1/.}.gz" ::: *.bz2
     """
 }
@@ -117,7 +117,7 @@ process pbmm2_align_02 {
     script:
     """
     #! /usr/bin/env bash
-    PROC=\$((`nproc`-10))
+    PROC=\$((`nproc` % 4))
     mkdir tmp
     pbmm2 align -j \$PROC ${assembly_fasta} ${pacbio_read} | samtools sort -T tmp -m 8G --threads 8 - > ${pacbio_read.simpleName}_aln.bam
     samtools index -@ \${PROC} ${pacbio_read.simpleName}_aln.bam
@@ -143,7 +143,7 @@ process gcc_Arrow_02 {
     script:
     """
     #! /usr/bin/env bash
-    PROC=\$((`nproc`-4))
+    PROC=\$((`nproc` % 4))
     gcpp --algorithm=arrow \
       -x 10 -X 120 -q 0 \
       -j \${PROC} -w \"$window\" \
@@ -195,7 +195,7 @@ process pbmm2_align_02b {
     script:
     """
     #! /usr/bin/env bash
-    PROC=\$((`nproc`-10))
+    PROC=\$((`nproc` % 4))
     mkdir tmp
     pbmm2 align -j \$PROC ${assembly_fasta} ${pacbio_read} | samtools sort -T tmp -m 8G --threads 8 - > ${pacbio_read.simpleName}_aln_2b.bam
     samtools index -@ \${PROC} ${pacbio_read.simpleName}_aln_2b.bam
@@ -262,7 +262,7 @@ process align_shortreads_04 {
     script:
     """
     #! /usr/bin/env bash
-    PROC=\$((`nproc`-4))
+    PROC=\$((`nproc` % 4))
     mkdir tmp
     bwa-mem2 index ${assembly_fasta}
     bwa-mem2 mem -SP -t \${PROC} ${assembly_fasta} ${illumina_one} ${illumina_two} |

--- a/main.nf
+++ b/main.nf
@@ -59,7 +59,7 @@ process bz_to_gz {
     script:
     """
     #! /usr/bin/env bash
-    PROC=\$((`nproc` % 4))
+    PROC=\$((`nproc` /2+1))
     parallel -j 2 "bzcat {1} | pigz -p \${PROC} > {1/.}.gz" ::: *.bz2
     """
 }
@@ -117,7 +117,7 @@ process pbmm2_align_02 {
     script:
     """
     #! /usr/bin/env bash
-    PROC=\$((`nproc` % 4))
+    PROC=\$((`nproc` /2+1))
     mkdir tmp
     pbmm2 align -j \$PROC ${assembly_fasta} ${pacbio_read} | samtools sort -T tmp -m 8G --threads 8 - > ${pacbio_read.simpleName}_aln.bam
     samtools index -@ \${PROC} ${pacbio_read.simpleName}_aln.bam
@@ -143,7 +143,7 @@ process gcc_Arrow_02 {
     script:
     """
     #! /usr/bin/env bash
-    PROC=\$((`nproc` % 4))
+    PROC=\$((`nproc` /2+1))
     gcpp --algorithm=arrow \
       -x 10 -X 120 -q 0 \
       -j \${PROC} -w \"$window\" \
@@ -195,7 +195,7 @@ process pbmm2_align_02b {
     script:
     """
     #! /usr/bin/env bash
-    PROC=\$((`nproc` % 4))
+    PROC=\$((`nproc` /2+1))
     mkdir tmp
     pbmm2 align -j \$PROC ${assembly_fasta} ${pacbio_read} | samtools sort -T tmp -m 8G --threads 8 - > ${pacbio_read.simpleName}_aln_2b.bam
     samtools index -@ \${PROC} ${pacbio_read.simpleName}_aln_2b.bam
@@ -221,7 +221,7 @@ process gcc_Arrow_02b {
     script:
     """
     #! /usr/bin/env bash
-    PROC=\$((`nproc`-4))
+    PROC=\$((`nproc` /2+1))
     gcpp --algorithm=arrow \
       -x 10 -X 120 -q 0 \
       -j \${PROC} -w \"$window\" \
@@ -262,7 +262,7 @@ process align_shortreads_04 {
     script:
     """
     #! /usr/bin/env bash
-    PROC=\$((`nproc` % 4))
+    PROC=\$((`nproc` /2+1))
     mkdir tmp
     bwa-mem2 index ${assembly_fasta}
     bwa-mem2 mem -SP -t \${PROC} ${assembly_fasta} ${illumina_one} ${illumina_two} |
@@ -350,7 +350,7 @@ process align_shortreads_06 {
     script:
     """
     #! /usr/bin/env bash
-    PROC=\$((`nproc`-4))
+    PROC=\$((`nproc` /2+1))
     mkdir tmp
     bwa-mem2 index ${assembly_fasta}
     bwa-mem2 mem -SP -t \${PROC} ${assembly_fasta} ${illumina_one} ${illumina_two} |


### PR DESCRIPTION
the nproc - 10 and -4 logic will error out when the system has been setup only to show users one thread (common on qsub and sbatch submission boxes) this pull request, which I dunno, is only one way to fix this odd problem instead setups thread numbers to nproc/2+1 so there will always be at least one that the applications can use. 

