### PR TITLE
Using parallel to speed up grep

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -312,9 +312,10 @@ process combineVCF_04 {
     script:
     """
     #! /usr/bin/env bash
+    PROC=\$((`nproc` /2+1))
     > consensus_04.vcf
-    cat ${vcfs.get(0)} | xargs -0 -n10 -P4 grep "^#" >> consensus_04.vcf
-    cat ${vcfs} | xargs -0 -n10 -P4 grep -v "^#" >> consensus_04.vcf
+    cat ${vcfs.get(0)} | xargs -0 -n10 -P${PROC} grep "^#" >> consensus_04.vcf
+    cat ${vcfs} | xargs -0 -n10 -P${PROC} grep -v "^#" >> consensus_04.vcf
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -312,8 +312,9 @@ process combineVCF_04 {
     script:
     """
     #! /usr/bin/env bash
-    cat ${vcfs.get(0)} | grep "^#" > consensus_04.vcf
-    cat ${vcfs} | grep -v "^#" >> consensus_04.vcf
+    > consensus_04.vcf
+    cat ${vcfs.get(0)} | xargs -0 -n10 -P4 grep "^#" >> consensus_04.vcf
+    cat ${vcfs} | xargs -0 -n10 -P4 grep -v "^#" >> consensus_04.vcf
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -314,8 +314,8 @@ process combineVCF_04 {
     #! /usr/bin/env bash
     PROC=\$((`nproc` /2+1))
     > consensus_04.vcf
-    cat ${vcfs.get(0)} | xargs -0 -n10 -P${PROC} grep "^#" >> consensus_04.vcf
-    cat ${vcfs} | xargs -0 -n10 -P${PROC} grep -v "^#" >> consensus_04.vcf
+    cat ${vcfs.get(0)} | parallel --max-procs $PROC --spreadstdin --pipe grep "^#" >> consensus_04.vcf
+    cat ${vcfs} | parallel --max-procs $PROC --spreadstdin --pipe grep -v "^#" >> consensus_04.vcf
     """
 }
 
@@ -402,8 +402,10 @@ process combineVCF_06 {
     script:
     """
     #! /usr/bin/env bash
-    cat ${vcfs.get(0)} | grep "^#" > consensus_06.vcf
-    cat ${vcfs} | grep -v "^#" >> consensus_06.vcf
+    PROC=\$((`nproc` /2+1))
+    > consensus_06.vcf
+    cat ${vcfs.get(0)} | parallel --max-procs $PROC --spreadstdin --pipe grep "^#" >> consensus_06.vcf
+    cat ${vcfs} | parallel --max-procs $PROC --spreadstdin --pipe grep -v "^#" >> consensus_06.vcf
     """
 }
 


### PR DESCRIPTION
This pull request, when tested and ready, will use GNU parallel (already in the conda environment) to multithread the greps for the vcf files, it mutlithreads at the pipe level instead of at the file level (so it splits vcf files into chunks of lines and greps those simultaneously). GNU Parallel has a nice feature of not interrupting line writes. 