### PR TITLE
feat: surface customized parameters for sub programs

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -69,6 +69,17 @@ def helpMessage() {
    --bcftools_app                 Link to bcftools executable [default: 'bcftools']
    --merfin_app                   Link to merfin executable [default: 'merfin']
 
+   Optional parameter arguments
+   --parallel_params              Parameters passed to parallel executable [default: ' -j 2 ']
+   --pbmm2_params                 Parameters passed to pbmm2 align [default: '']
+   --minimap2_params              Parameters passed to minimap2 -xmap-pb or -xasm5 [default: '']
+   --gcpp_params                  Parameters passed to gcpp [default: ' -x 10 -X 120 -q 0 ']
+   --bwamem2_params               Parameters passed to bwamem2 [default: ' -SP ']
+   --freebayes_params             Parameters passed to freebayes [default: ' --min-mapping-quality 0 --min-coverage 3 --min-supporting-allele-qsum 0  --ploidy 2 --min-alternate-fraction 0.2 --max-complex-gap 0 ']
+   --purge_dups_params            Parameters passed to purge_dups [default: ' -2 -T p_cufoffs ']
+   --busco_params                 Parameters passed to busco [default: ' -l insecta_odb10 -m genome -f ']
+
+
    Optional arguments:
    --outdir                       Output directory to place final output [default: 'PolishCLR_Results']
    --clusterOptions               Cluster options for slurm or sge profiles [default slurm: '-N 1 -n 40 -t 04:00:00'; default sge: ' ']

--- a/modules/arrow.nf
+++ b/modules/arrow.nf
@@ -35,7 +35,7 @@ process pbmm2_align {
   # for multiple pacbio subread files
   ls ${pacbio_read} > bam.fofn
 
-  ${pbmm2_app} align -j \$PROC ${assembly_fasta} bam.fofn | \
+  ${pbmm2_app} align ${pbmm2_params} -j \$PROC ${assembly_fasta} bam.fofn | \
     ${samtools_app} sort -T tmp -m 8G --threads \$PROC2 - > ${assembly_fasta.simpleName}_aln.bam
   ${samtools_app} index -@ \${PROC} ${assembly_fasta.simpleName}_aln.bam
   """
@@ -58,7 +58,7 @@ process gcpp_arrow {
   #! /usr/bin/env bash
   PROC=\$(((`nproc`-1)*3/4+1))
   ${gcpp_app} --algorithm=arrow \
-    -x 10 -X 120 -q 0 \
+    ${gcpp_params} \
     -j \${PROC} -w "$window" \
     -r ${assembly_fasta} ${pacbio_bam} \
     -o ${assembly_fasta.simpleName}_${window.replace(':','_').replace('|','_')}.vcf,${assembly_fasta.simpleName}_${window.replace(':','_').replace('|','_')}.fasta

--- a/modules/busco.nf
+++ b/modules/busco.nf
@@ -33,10 +33,8 @@ process BUSCO {
   ${busco_app} \
     -o ${genomeFile.simpleName} \
     -i ${genomeFile.simpleName}_fixheaders.fna \
-    -l ${busco_lineage} \
-    -m genome \
-    -c \${PROC} \
-    -f
+    ${busco_params} \
+    -c \${PROC} 
 
 else 
   mkdir ${genomeFile.simpleName}

--- a/modules/freebayes.nf
+++ b/modules/freebayes.nf
@@ -15,7 +15,7 @@ process align_shortreads {
   PROC2=\$(((`nproc`-1)*1/4+1))
   mkdir tmp
   ${bwamem2_app} index ${assembly_fasta}
-  ${bwamem2_app} mem -SP -t \$PROC ${assembly_fasta} ${illumina_one} ${illumina_two} | \
+  ${bwamem2_app} mem ${bwamem2_params} -t \$PROC ${assembly_fasta} ${illumina_one} ${illumina_two} | \
     ${samtools_app} sort -T tmp -m 8G --threads \$PROC2 - > ${illumina_one.simpleName}_aln.bam
   ${samtools_app} index -@ \${PROC} ${illumina_one.simpleName}_aln.bam
   """
@@ -38,12 +38,7 @@ process freebayes {
   #! /usr/bin/env bash
   ${freebayes_app} \
     --region "${window}" \
-    --min-mapping-quality 0 \
-    --min-coverage 3 \
-    --min-supporting-allele-qsum 0 \
-    --ploidy 2 \
-    --min-alternate-fraction 0.2 \
-    --max-complex-gap 0 \
+    ${freebayes_params} \
     --bam ${illumina_bam} \
     --vcf ${illumina_bam.simpleName}_${window.replace(':','_').replace('|','_')}.vcf \
     --fasta-reference ${assembly_fasta}

--- a/modules/helper_functions.nf
+++ b/modules/helper_functions.nf
@@ -12,7 +12,7 @@ process bz_to_gz {
   #! /usr/bin/env bash
 
   PROC=\$(((`nproc`-1)/2+1))
-  ${parallel_app} -j 2 "${bzcat_app} {1} | ${pigz_app} -p \${PROC} > {1/.}.gz" ::: *.bz2
+  ${parallel_app} ${parallel_params} "${bzcat_app} {1} | ${pigz_app} -p \${PROC} > {1/.}.gz" ::: *.bz2
   """
 
   stub:
@@ -329,7 +329,9 @@ process merfin_polish {
     -readmers ${meryldb} \
     -peak ${peak} \
     -vcf ${vcf} \
-    -output \${OUTNAME}_merfin
+    -output \${OUTNAME}_merfin \
+    ${merfin_params}
+    
   """
   
   stub:

--- a/nextflow.config
+++ b/nextflow.config
@@ -38,16 +38,22 @@ params {
 
   /* link executables (optional) */
   parallel_app = 'parallel'
+  parallel_params = ' -j 2 '
   bzcat_app = 'bzcat'
   pigz_app = 'pigz'
   meryl_app = 'meryl'
   merqury_sh = '$MERQURY/merqury.sh'
   pbmm2_app = 'pbmm2'
+  pbmm2_params = ' '
   minimap2_app = 'minimap2'
+  minimap2_params = ' '
   samtools_app = 'samtools'
   gcpp_app = 'gcpp'
+  gcpp_params = ' -x 10 -X 120 -q 0 '
   bwamem2_app = 'bwa-mem2'
+  bwamem2_params = ' -SP '
   freebayes_app = 'freebayes'
+  freebayes_params = ' --min-mapping-quality 0 --min-coverage 3 --min-supporting-allele-qsum 0  --ploidy 2 --min-alternate-fraction 0.2 --max-complex-gap 0 '
   bcftools_app = 'bcftools'
   merfin_app = 'merfin'
   pbcstat_app = 'pbcstat'
@@ -55,10 +61,11 @@ params {
   calcuts_app = 'calcuts'
   split_fa_app = 'split_fa'
   purge_dups_app = 'purge_dups'
+  purge_dups_params = ' -2 -T p_cufoffs '
   get_seqs_app = 'get_seqs'
   gzip_app = 'gzip'
   busco_app = 'busco'
-  busco_lineage = 'insecta_odb10'  // --auto-lineage, can also pass in full path to predownloaded busco files
+  busco_params = ' -l insecta_odb10 -m genome -f '
 
   /* hacky way of throwing an error on --profile, when it should be -profile */
   profile = false
@@ -66,15 +73,21 @@ params {
 
 env {
   parallel_app = "$params.parallel_app"
+  parallel_params = "$params.parallel_params"
   bzcat_app = "$params.bzcat_app"
   pigz_app = "$params.pigz_app"
   meryl_app = "$params.meryl_app"
   pbmm2_app = "$params.pbmm2_app"
+  pbmm2_params = "$params.pbmm2_params"
   minimap2_app = "$params.minimap2_app"
+  minimap2_params = "$params.minimap2_params"
   samtools_app = "$params.samtools_app"
   gcpp_app = "$params.gcpp_app"
+  gcpp_params = "$params.gcpp_params"
   bwamem2_app = "$params.bwamem2_app"
+  bwamem2_params = "$params.bwamem2_params"
   freebayes_app = "$params.freebayes_app"
+  freebayes_params = "$params.freebayes_params"
   bcftools_app = "$params.bcftools_app"
   merfin_app = "$params.merfin_app"
   pbcstat_app = "$params.pbcstat_app"
@@ -82,10 +95,11 @@ env {
   calcuts_app = "$params.calcuts_app"
   split_fa_app = "$params.split_fa_app"
   purge_dups_app = "$params.purge_dups_app"
+  purge_dups_params = "$params.purge_dups_params"
   get_seqs_app = "$params.get_seqs_app"
   gzip_app = "$params.gzip_app"
   busco_app = "$params.busco_app"
-  busco_lineage = "$params.busco_lineage"
+  busco_params = "$params.busco_params"
 }
 
 process {

--- a/templates/purge_dups.sh
+++ b/templates/purge_dups.sh
@@ -11,7 +11,7 @@ PROC=\$((`nproc`))
 ${samtools_app} faidx ${primary_assembly}
 
 for x in ${pacbio_reads.simpleName} ; do
-       ${minimap2_app} -xmap-pb $primary_assembly \${x}.fasta | $gzip_app -c - > \${x}_p_mapping.paf.gz
+       ${minimap2_app} -xmap-pb ${params.minimap2_params} $primary_assembly \${x}.fasta | $gzip_app -c - > \${x}_p_mapping.paf.gz
 done
 
 ${pbcstat_app} *_p_mapping.paf.gz
@@ -20,9 +20,9 @@ ${calcuts_app} PB.stat > p_cutoffs 2> p_calcuts.log
 
 ${split_fa_app} ${primary_assembly} > ${primary_assembly}.split
 
-${minimap2_app} -xasm5 -DP -t \${PROC} ${primary_assembly}.split ${primary_assembly}.split | gzip -c - > ${primary_assembly}.split.self.paf.gz
+${minimap2_app} -xasm5 ${params.minimap2_params} -DP -t \${PROC} ${primary_assembly}.split ${primary_assembly}.split | gzip -c - > ${primary_assembly}.split.self.paf.gz
 
-${purge_dups_app} -2 -T p_cufoffs -c PB.base.cov ${primary_assembly}.split.self.paf.gz > p_dups.bed 2> p_purge_dups.log
+${purge_dups_app} ${purge_dups_params} -c PB.base.cov ${primary_assembly}.split.self.paf.gz > p_dups.bed 2> p_purge_dups.log
 
 ## -e flag to only remove haplotypic regions at the ends of contigs
 ${get_seqs_app} -e p_dups.bed ${primary_assembly} -p primary
@@ -35,7 +35,7 @@ cat primary.hap.fa  ${haplo_fasta} >  h_${haplo_fasta}
 ${samtools_app} faidx h_${haplo_fasta}
 
 for x in ${pacbio_reads.simpleName} ; do
-       ${minimap2_app} -xmap-pb h_${haplo_fasta} \${x}.fasta | $gzip_app -c - > \${x}_h_mapping.paf.gz
+       ${minimap2_app} -xmap-pb ${params.minimap2_params} h_${haplo_fasta} \${x}.fasta | $gzip_app -c - > \${x}_h_mapping.paf.gz
 done
 
 ${pbcstat_app} *_h_mapping.paf.gz
@@ -44,10 +44,10 @@ ${calcuts_app} PB.stat > h_cutoffs 2> h_calcuts.log
 
 ${split_fa_app} h_${haplo_fasta} > h_${haplo_fasta}.split
 
-${minimap2_app} -xasm5 -DP -t \${PROC} h_${haplo_fasta}.split h_${haplo_fasta}.split |\
+${minimap2_app} -xasm5 ${params.minimap2_params} -DP -t \${PROC} h_${haplo_fasta}.split h_${haplo_fasta}.split |\
   ${gzip_app} -c - > h_${haplo_fasta}.split.self.paf.gz
 
-${purge_dups_app} -2 -T h_cufoffs -c PB.base.cov h_${haplo_fasta}.split.self.paf.gz > h_dups.bed 2> h_purge_dups.log
+${purge_dups_app} ${purge_dups_params} -c PB.base.cov h_${haplo_fasta}.split.self.paf.gz > h_dups.bed 2> h_purge_dups.log
 
 ${get_seqs_app} -e h_dups.bed h_${haplo_fasta} -p haps
 

--- a/templates/purge_dups_trios.sh
+++ b/templates/purge_dups_trios.sh
@@ -17,7 +17,7 @@ PROC=\$((`nproc`))
 ${samtools_app} faidx ${primary_assembly}
 
 for x in ${pacbio_reads.simpleName} ; do
-       ${minimap2_app} -xmap-pb $primary_assembly \${x}.fasta | $gzip_app -c - > \${x}_p_mapping.paf.gz
+       ${minimap2_app} -xmap-pb ${params.minimap2_params} $primary_assembly \${x}.fasta | $gzip_app -c - > \${x}_p_mapping.paf.gz
 done
 
 ${pbcstat_app} *_${primary_assembly.shortName}_mapping.paf.gz
@@ -27,9 +27,9 @@ ${calcuts_app} PB.stat > p_cutoffs 2> p_calcuts.log
 
 ${split_fa_app} ${primary_assembly} > ${primary_assembly.shortName}.split
 
-${minimap2_app} -xasm5 -DP -t \${PROC} ${primary_assembly.shortName}.split ${primary_assembly.shortName}.split | gzip -c - > ${primary_assembly.shortName}.split.self.paf.gz
+${minimap2_app} -xasm5 ${params.minimap2_params} -DP -t \${PROC} ${primary_assembly.shortName}.split ${primary_assembly.shortName}.split | gzip -c - > ${primary_assembly.shortName}.split.self.paf.gz
 
-${purge_dups_app} -2 -T p_cufoffs -c PB.base.cov ${primary_assembly.shortName}.split.self.paf.gz > ${primary_assembly.shortName}_dups.bed 2> ${primary_assembly.shortName}_purge_dups.log
+${purge_dups_app} ${purge_dups_params} -c PB.base.cov ${primary_assembly.shortName}.split.self.paf.gz > ${primary_assembly.shortName}_dups.bed 2> ${primary_assembly.shortName}_purge_dups.log
 
 ## In trio assemblies there shouldn't be haplotigs, so remove these from the bed file output by purge_dups.bed
 grep 'JUNK\|OVLP' ${primary_assembly.shortName}_dups.bed > ${primary_assembly.shortName}_dups_JUNK_OVLP.bed


### PR DESCRIPTION
## Description

Allow users to pass in their customized params for:

* parallel
* gcpp_params
* freebayes_params
* purge_dups_params
* busco_params

The following params influence mapping/alignment, not indexing

* minimap2_params
* pbmm2_params
* bwamem2_params

Programs that are referenced multiple times in the pipeline will be difficult to parameterize without breaking something. These programs include samtools, bcftools, pbcstat, calcuts, split_fa, get_seqs, gzip

## Testing

Ideally run this on a dataset to make sure parameters are being passed properly. However, for now can simply test a stub

Assuming reviewer has nextflow installed:

```
nextflow -version
```

Can test by creating empty input files, and running remotely the "params" branch.

```
mkdir data 
cd data
touch pri.fa alt.fa mit.fa ill_R1.fastq.bz2 ill_R2.fastq.bz2 pac.subreads.bam
cd ..

nextflow run isugifNF/polishCLR -r params \
            --primary_assembly data/pri.fa \
            --alternate_assembly data/alt.fa \
            --mitochondrial_assembly data/mit.fa \
            --illumina_reads "data/ill_{R1,R2}.fastq.bz2" \
            --pacbio_reads data/pac.subreads.bam \
            --species "BugName" \
            --k "21" \
            --falcon_unzip true \
            --step 1 \
            -stub-run \
            -profile local
```
