### PR TITLE
reformat: readability

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -3,27 +3,59 @@
 nextflow.enable.dsl=2
 
 // === Import Modules
-// create meryl database
-include { meryl_count; meryl_union; meryl_peak } from './modules/qv.nf'
-// QV checks
-include { MerquryQV as MerquryQV_00; MerquryQV as MerquryQV_01; MerquryQV as MerquryQV_04; MerquryQV as MerquryQV_05; MerquryQV as MerquryQV_06 } from './modules/qv.nf'
-include {bbstat as bbstat_00; bbstat as bbstat_01; bbstat as bbstat_04; bbstat as bbstat_05; bbstat as bbstat_06} from './modules/qv.nf'
+// Creates Meryl Database and checks QV
+include { meryl_count;
+          meryl_union;
+          meryl_peak;
+          MerquryQV as MerquryQV_00;
+          MerquryQV as MerquryQV_01;
+          MerquryQV as MerquryQV_04;
+          MerquryQV as MerquryQV_05;
+          MerquryQV as MerquryQV_06;
+          bbstat as bbstat_00;
+          bbstat as bbstat_01;
+          bbstat as bbstat_04;
+          bbstat as bbstat_05;
+          bbstat as bbstat_06 } from './modules/qv.nf'
 
-// Arrow workflows
-include { ARROW as ARROW_02; ARROW as ARROW_02b; ARROW_MERFIN as ARROW_04; ARROW_MERFIN as ARROW_04b } from './modules/arrow.nf'
-// FreeBayes workflows
-include { FREEBAYES as FREEBAYES_05; FREEBAYES as FREEBAYES_05b; FREEBAYES as FREEBAYES_06; FREEBAYES as FREEBAYES_06b } from './modules/freebayes.nf'
-// Preprocess and helper functions
-include {bz_to_gz; MERGE_FILE as MERGE_FILE_00; MERGE_FILE_TRIO; SPLIT_FILE as SPLIT_FILE_02; SPLIT_FILE as SPLIT_FILE_07} from './modules/helper_functions.nf'
-include {SPLIT_FILE_CASE1 as SPLIT_FILE_CASE1} from './modules/helper_functions.nf'
-include {SPLIT_FILE_p as SPLIT_FILE_02p; SPLIT_FILE_m as SPLIT_FILE_02m} from './modules/helper_functions.nf'
-include {SPLIT_FILE_p as SPLIT_FILE_07p; SPLIT_FILE_m as SPLIT_FILE_07m} from './modules/helper_functions.nf'
+// Arrow polishing
+include { ARROW as ARROW_02;
+          ARROW as ARROW_02b;
+          ARROW_MERFIN as ARROW_04;
+          ARROW_MERFIN as ARROW_04b } from './modules/arrow.nf'
+
+// FreeBayes polishing
+include { FREEBAYES as FREEBAYES_05;
+          FREEBAYES as FREEBAYES_05b;
+          FREEBAYES as FREEBAYES_06;
+          FREEBAYES as FREEBAYES_06b } from './modules/freebayes.nf'
+
+// Preprocess, postprocess, and helper functions
+include { bz_to_gz;
+          MERGE_FILE as MERGE_FILE_00;
+          MERGE_FILE_TRIO;
+          SPLIT_FILE as SPLIT_FILE_02;
+          SPLIT_FILE as SPLIT_FILE_07;
+          SPLIT_FILE_CASE1 as SPLIT_FILE_CASE1;
+          SPLIT_FILE_p as SPLIT_FILE_02p;
+          SPLIT_FILE_m as SPLIT_FILE_02m;
+          SPLIT_FILE_p as SPLIT_FILE_07p;
+          SPLIT_FILE_m as SPLIT_FILE_07m;
+          RENAME_FILE as RENAME_PRIMARY;
+          RENAME_FILE as RENAME_PAT;
+          RENAME_FILE as RENAME_MAT;
+          MERGE_FILE_CASE1 as MERGE_CASE1;
+          bam_to_fasta } from './modules/helper_functions.nf'
+
 // Other
-include { PURGE_DUPS as PURGE_DUPS_02; PURGE_DUPS_CASE1 as PURGE_DUPS_CASE1; PURGE_DUPS_TRIO as PURGE_DUPS_TRIOp; PURGE_DUPS_TRIO as PURGE_DUPS_TRIOm } from './modules/purge_dups.nf'
-include { BUSCO; BUSCO as BUSCO_CASE1; BUSCO as BUSCO_mat } from './modules/busco.nf'
+include { PURGE_DUPS as PURGE_DUPS_02;
+          PURGE_DUPS_CASE1 as PURGE_DUPS_CASE1;
+          PURGE_DUPS_TRIO as PURGE_DUPS_TRIOp;
+          PURGE_DUPS_TRIO as PURGE_DUPS_TRIOm } from './modules/purge_dups.nf'
 
-include {RENAME_FILE as RENAME_PRIMARY; RENAME_FILE as RENAME_PAT; RENAME_FILE as RENAME_MAT} from './modules/helper_functions.nf'
-include {MERGE_FILE_CASE1 as MERGE_CASE1; bam_to_fasta } from './modules/helper_functions.nf'
+include { BUSCO;
+          BUSCO as BUSCO_CASE1;
+          BUSCO as BUSCO_mat } from './modules/busco.nf'
 
 def helpMessage() {
   log.info isuGIFHeader()
@@ -33,28 +65,28 @@ def helpMessage() {
    nextflow run main.nf --primary_assembly "*fasta" --illumina_reads "*{1,2}.fastq.bz2" --pacbio_reads "*_subreads.bam" -resume
 
    Mandatory arguments:
-   --illumina_reads               paired end illumina reads, to be used for Merqury QV scores, and freebayes polish primary assembly
-   --pacbio_reads                 pacbio reads in bam format, to be used to arrow polish primary assembly
-   --mitochondrial_assembly       mitocondrial assembly will be concatinated to the assemblies before polishing [default: false]
+   --illumina_reads               Paired end Illumina reads, to be used for Merqury QV scores, and FreeBayes polish primary assembly
+   --pacbio_reads                 PacBio reads in bam format, to be used to Arrow polish primary assembly
+   --mitochondrial_assembly       Mitocondrial assembly will be concatinated to the assemblies before polishing [default: false]
 
-   Either FALCON (or FALCON Unzip) assembly:
-   --primary_assembly             genome assembly fasta file to polish
-   --alternate_assembly           if alternate/haplotig assembly file is provided, will be concatinated to the primary assembly before polishing [default: false]
-   --falcon_unzip                 if primary assembly has already undergone falcon unzip [default: false]. If true, will Arrow polish once instead of twice.
-   
+   Either FALCON (or FALCON-Unzip) assembly:
+   --primary_assembly             Genome assembly fasta file to polish
+   --alternate_assembly           If alternate/haplotig assembly file is provided, will be concatinated to the primary assembly before polishing [default: false]
+   --falcon_unzip                 If primary assembly has already undergone FALCON-Unzip [default: false]. If true, will Arrow polish once instead of twice.
+
    Or TrioCanu assembly
-   --paternal_assembly            paternal genome assembly fasta file to polish
-   --maternal_assembly            maternal genome assembly fasta file to polish
+   --paternal_assembly            Paternal genome assembly fasta file to polish
+   --maternal_assembly            Maternal genome assembly fasta file to polish
 
-   Pick Step 1 (arrow, purgedups) or Step 2 (arrow, freebayes, freebayes)
+   Pick Step 1 (arrow, purgedups) or Step 2 (Arrow, FreeBayes, FreeBayes)
    --step                         Run step 1 or step 2 (default: 1)
 
-   Optional modifiers   
-   --species                      if a string is given, rename the final assembly by species name [default:false]
+   Optional modifiers
+   --species                      If a string is given, rename the final assembly by species name [default:false]
    --k                            kmer to use in MerquryQV scoring [default:21]
-   --same_specimen                if illumina and pacbio reads are from the same specimin [default: true].
-   --meryldb                      path to a prebuilt meryl database, built from the illumina reads. If not provided, tehen build.
-   
+   --same_specimen                If Illumina and PacBio reads are from the same specimin [default: true].
+   --meryldb                      Path to a prebuilt Meryl database, built from the Illumina reads. If not provided, then build.
+
    Optional configuration arguments
    --parallel_app                 Link to parallel executable [default: 'parallel']
    --bzcat_app                    Link to bzcat executable [default: 'bzcat']
@@ -87,7 +119,7 @@ def helpMessage() {
    --queueSize                    Maximum number of jobs to be queued [default: 50]
    --account                      Some HPCs require you supply an account name for tracking usage.  You can supply that here.
    --help                         This usage statement.
-   --check_software               Check if software dependencies are available.               
+   --check_software               Check if software dependencies are available.
   """
 }
 
@@ -112,15 +144,15 @@ if ( params.profile ) {
 }
 
 def parameters_valid = ['help','monochrome_logs','outdir',
-'primary_assembly','alternate_assembly','paternal_assembly','maternal_assembly','mitochondrial_assembly',
-'illumina_reads','pacbio_reads','k','species','meryldb','falcon_unzip','same_specimen','steptwo','step',
-'queueSize','account','threads','clusterOptions',
-'queue-size', 'cluster-options',
-'parallel_app','bzcat_app','pigz_app','meryl_app','merqury_sh','pbmm2_app','minimap2_app','samtools_app',
-'gcpp_app','bwamem2_app','freebayes_app','bcftools_app','merfin_app','pbcstat_app','hist_plot_py',
-'calcuts_app','split_fa_app','purge_dups_app','get_seqs_app','gzip_app','busco_app','busco_lineage',
-'parallel_params','pbmm2_params','minimap2_params','gcpp_params','bwamem2_params','freebayes_params',
-'purge_dups_params','busco_params','check_software','profile'] as Set
+  'primary_assembly','alternate_assembly','paternal_assembly','maternal_assembly','mitochondrial_assembly',
+  'illumina_reads','pacbio_reads','k','species','meryldb','falcon_unzip','same_specimen','steptwo','step',
+  'queueSize','account','threads','clusterOptions',
+  'queue-size', 'cluster-options',
+  'parallel_app','bzcat_app','pigz_app','meryl_app','merqury_sh','pbmm2_app','minimap2_app','samtools_app',
+  'gcpp_app','bwamem2_app','freebayes_app','bcftools_app','merfin_app','pbcstat_app','hist_plot_py',
+  'calcuts_app','split_fa_app','purge_dups_app','get_seqs_app','gzip_app','busco_app','busco_lineage',
+  'parallel_params','pbmm2_params','minimap2_params','gcpp_params','bwamem2_params','freebayes_params',
+  'purge_dups_params','busco_params','check_software','profile'] as Set
 
 def parameter_diff = params.keySet() - parameters_valid
 if (parameter_diff.size() != 0){
@@ -153,193 +185,276 @@ process check_software {
   [[ -z `which $get_seqs_app` ]]   && echo "${get_seqs_app}   .... need to install." && ERR=1 || echo "${get_seqs_app}   .... good. " `${get_seqs_app} -h &> temp ; head -n2 temp | tail -n1`
   [[ -z `which $gzip_app` ]]       && echo "${gzip_app}       .... need to install." && ERR=1 || echo "${gzip_app}       .... good. " `${gzip_app} --version | head -n1`
   [[ -z `which $busco_app ` ]]     && echo "${busco_app}      .... need to install." && ERR=1 || echo "${busco_app}      .... good. " `${busco_app} --version`
-  
+
   """
 }
 
 workflow {
-  if( params.check_software ) {
+  if ( params.check_software ) {
     check_software()
     | view
   } else {
-  // === Setup input channels
-  // Case 2 or Case 3: Primary, alternate, and mito exist
-  if( params.alternate_assembly ){ 
-    mito_ch = channel.fromPath(params.mitochondrial_assembly, checkIfExists:true)
-    alt_ch = channel.fromPath(params.alternate_assembly, checkIfExists:true)
-    pri_ch = channel.fromPath(params.primary_assembly, checkIfExists:true) |
-      combine(channel.of("${params.species}_pri.fasta")) | RENAME_PRIMARY
+    // === Setup input channels
+    // Case 2 or Case 3: Primary, alternate, and mito exist
+    if ( params.alternate_assembly ) {
+      mitochondrial_ch = channel.fromPath(params.mitochondrial_assembly, checkIfExists:true)
+      alternate_assembly_ch = channel.fromPath(params.alternate_assembly, checkIfExists:true)
+      primary_assembly_ch = channel.fromPath(params.primary_assembly, checkIfExists:true)
+        | combine(channel.of("${params.species}_pri.fasta"))
+        | RENAME_PRIMARY
 
-    asm_ch = pri_ch | combine(alt_ch) | combine(mito_ch) | MERGE_FILE_00
+      assembly_ch = primary_assembly_ch
+        | combine(alternate_assembly_ch)
+        | combine(mitochondrial_ch)
+        | MERGE_FILE_00
 
-  } else if ( params.primary_assembly ) { // Option 1b: Canu, same as Falcon but without alternative assembly
-    if( params.mitochondrial_assembly ) {  // merge mito if available
-      mito_ch = channel.fromPath(params.mitochondrial_assembly, checkIfExists:true)
-      pri_ch = channel.fromPath(params.primary_assembly, checkIfExists:true) |
-        combine(channel.of("${params.species}_pri.fasta")) | RENAME_PRIMARY
+    } else if ( params.primary_assembly ) { // Option 1b: Canu, same as FALCON but without alternative assembly
+      if ( params.mitochondrial_assembly ) {  // Merge mitochondrial assembly if available
+        mitochondrial_ch = channel.fromPath(params.mitochondrial_assembly, checkIfExists:true)
+        primary_assembly_ch = channel.fromPath(params.primary_assembly, checkIfExists:true)
+          | combine(channel.of("${params.species}_pri.fasta"))
+          | RENAME_PRIMARY
 
-      asm_ch = pri_ch | combine(mito_ch) | MERGE_CASE1
-    } else { // mito not available, may still have issues with split_file
-      asm_ch = channel.fromPath(params.primary_assembly, checkIfExists:true) |
-        combine(channel.of("${params.species}_pri.fasta")) | RENAME_PRIMARY
-    }
-  } else if ( params.paternal_assembly ) {  // Option 2: read in TrioCanu assembly
-    mito_ch = channel.fromPath(params.mitochondrial_assembly, checkIfExists:true)
-    pat_ch = channel.fromPath(params.paternal_assembly, checkIfExists:true) | 
-      combine(channel.of("${params.species}_pat.fasta")) | RENAME_PAT
-    mat_ch = channel.fromPath(params.maternal_assembly, checkIfExists:true) |
-      combine(channel.of("${params.species}_mat.fasta")) | RENAME_MAT
+        assembly_ch = primary_assembly_ch
+          | combine(mitochondrial_ch)
+          | MERGE_CASE1
 
-    // should result in Paternal and Material assemblies being polished separately
-    asm_ch = pat_ch | concat(mat_ch) | combine(mito_ch) | MERGE_FILE_TRIO
-  }
-  
-  k_ch   = channel.of(params.k) // Either passed in or autodetect (there's a script for this)
-  pac_ch = channel.fromPath(params.pacbio_reads, checkIfExists:true)
-  pacall_ch = pac_ch | collect | map {n -> [n]}
-  // Step 0: Preprocess illumina files from bz2 to gz files. Instead of a flag, auto detect, however it must be in the pattern, * will fail
-  if(params.illumina_reads =~ /bz2$/){
-    ill_ch = channel.fromFilePairs(params.illumina_reads, checkIfExists:true) | bz_to_gz | map { n -> n.get(1) } | flatten
-  }else{
-    ill_ch = channel.fromFilePairs(params.illumina_reads, checkIfExists:true) | map { n -> n.get(1) } | flatten
-  }
-  // Create meryl database and compute peak
-  if( params.meryldb ) {  // If prebuilt, will save time
-    merylDB_ch = channel.fromPath(params.meryldb, checkIfExists:true)
-  } else {
-    merylDB_ch = k_ch | combine(ill_ch) | meryl_count | collect | meryl_union
-  }
-  peak_ch = merylDB_ch | meryl_peak | map { n -> n.get(0) } | splitText() { it.trim() }
-
-  // Step 1: Check quality of assembly with Merqury and length dist. with bbstat
-  channel.of("00_Preprocess/00_QV") | combine(merylDB_ch) | combine(asm_ch) | MerquryQV_00
-  channel.of("00_Preprocess/00_bbstat") | combine(asm_ch) | bbstat_00
-
-  if( params.step == 1 ) { // TODO: redo this more elegantly later 
-
-    if (!params.falcon_unzip) {
-      // Step 2: Arrow Polish with PacBio reads
-      if(params.primary_assembly){
-        asm_arrow_ch = ARROW_02(channel.of("Step_1/01_ArrowPolish"), asm_ch, pacall_ch)
-      }else if (params.paternal_assembly) {
-        asm_arrowp_ch = ARROW_02(channel.of("Step_1/01_ArrowPolish_pat"), asm_ch.first(), pacall_ch)
-        asm_arrowm_ch = ARROW_02b(channel.of("Step_1/01_ArrowPolish_mat"), asm_ch.last(), pacall_ch)
-        asm_arrow_ch = asm_arrowp_ch | concat(asm_arrowm_ch)
+      } else { // If mitochondrial assembly not available, may still have issues with split_file
+        assembly_ch = channel.fromPath(params.primary_assembly, checkIfExists:true)
+          | combine(channel.of("${params.species}_pri.fasta"))
+          | RENAME_PRIMARY
       }
-      
-      // Step 3: Check quality of new assembly with Merqury 
-      channel.of("Step_1/01_QV") | combine(merylDB_ch) | combine(asm_arrow_ch) | MerquryQV_01
-      channel.of("Step_1/01_bbstat") | combine(asm_arrow_ch) | bbstat_01
+    } else if ( params.paternal_assembly ) {  // Option 2: read in TrioCanu assembly
+      mitochondrial_ch = channel.fromPath(params.mitochondrial_assembly, checkIfExists:true)
+      paternal_assembly_ch = channel.fromPath(params.paternal_assembly, checkIfExists:true)
+        | combine(channel.of("${params.species}_pat.fasta"))
+        | RENAME_PAT
+      maternal_assembly_ch = channel.fromPath(params.maternal_assembly, checkIfExists:true)
+        | combine(channel.of("${params.species}_mat.fasta"))
+        | RENAME_MAT
+
+      // Should result in Paternal and Material assemblies being polished separately
+      assembly_ch = paternal_assembly_ch
+        | concat(maternal_assembly_ch)
+        | combine(mitochondrial_ch)
+        | MERGE_FILE_TRIO
+    }
+
+    k_ch   = channel.of(params.k)
+    pacbio_reads_ch = channel.fromPath(params.pacbio_reads, checkIfExists:true)
+    pacbio_all_ch = pacbio_reads_ch
+      | collect
+      | map {n -> [n]}
+
+    // Step 0: Preprocess Illumina files from bz2 to gz files. Instead of a flag, auto detect, however it must be in the pattern, * will fail
+    if ( params.illumina_reads =~ /bz2$/ ) {
+      illumina_reads_ch = channel.fromFilePairs(params.illumina_reads, checkIfExists:true)
+        | bz_to_gz
+        | map { n -> n.get(1) }
+        | flatten
     } else {
-      asm_arrow_ch = asm_ch
+      illumina_reads_ch = channel.fromFilePairs(params.illumina_reads, checkIfExists:true)
+        | map { n -> n.get(1) }
+        | flatten
+    }
+    // Create meryl database and compute peak
+    if ( params.meryldb ) {
+      merylDB_ch = channel.fromPath(params.meryldb, checkIfExists:true)
+    } else {
+      merylDB_ch = k_ch
+        | combine(illumina_reads_ch)
+        | meryl_count
+        | collect
+        | meryl_union
     }
 
-    pacfasta_ch = pac_ch | bam_to_fasta | collect | map {n -> [n]}
+    peak_ch = merylDB_ch
+      | meryl_peak
+      | map { n -> n.get(0) }
+      | splitText() { it.trim() }
 
-    if(params.primary_assembly){
+    // Step 1: Check quality of assembly with Merqury and length dist. with bbstat
+    channel.of("00_Preprocess/00_QV")
+      | combine(merylDB_ch)
+      | combine(assembly_ch)
+      | MerquryQV_00
+    channel.of("00_Preprocess/00_bbstat")
+      | combine(assembly_ch)
+      | bbstat_00
 
-	// Case 1 - primary and mito assembly, no alternate. 
-	if(!params.alternate_assembly) {
-        tmp_ch = channel.of("Step_1/01_ArrowPolish") | combine(asm_arrow_ch) | SPLIT_FILE_CASE1 |
-        map {n -> [n.get(0)] }
-      channel.of("Step_1/02_Purge_Dups") |
-        combine(tmp_ch) |
-        combine(pacfasta_ch) |
-        PURGE_DUPS_CASE1
+    if ( params.step == 1 ) {
 
-      PURGE_DUPS_CASE1.out | map {n -> [n.get(0), n.get(1)] } | flatMap |
-      combine(channel.of("Step_1/02_BUSCO")) | map {n -> [n.get(1), n.get(0)]} |
-      BUSCO_CASE1
-	}      
+      if (!params.falcon_unzip) {
+        // Step 2: Arrow Polish with PacBio reads
+        if ( params.primary_assembly ) {
+          asm_arrow_ch = ARROW_02(channel.of("Step_1/01_ArrowPolish"), assembly_ch, pacbio_all_ch)
+        } else if ( params.paternal_assembly ) {
+          asm_arrow_pat_ch = ARROW_02(channel.of("Step_1/01_ArrowPolish_pat"), assembly_ch.first(), pacbio_all_ch)
+          asm_arrow_mat_ch = ARROW_02b(channel.of("Step_1/01_ArrowPolish_mat"), assembly_ch.last(), pacbio_all_ch)
+          asm_arrow_ch = asm_arrow_pat_ch
+            | concat(asm_arrow_mat_ch)
+        }
 
-	if(params.alternate_assembly) {
-	tmp_ch = channel.of("Step_1/01_ArrowPolish") | combine(asm_arrow_ch) | SPLIT_FILE_02 |
-        map {n -> [n.get(0), n.get(1)] }
-      channel.of("Step_1/02_Purge_Dups") |
-        combine(tmp_ch) |
-        combine(pacfasta_ch) |
-        PURGE_DUPS_02
-  
-      /* BUSCO check will go here */
-      PURGE_DUPS_02.out | map {n -> [n.get(0), n.get(1)] } | flatMap | 
-      combine(channel.of("Step_1/02_BUSCO")) | map {n -> [n.get(1), n.get(0)]} |
-      BUSCO
+        // Step 3: Check quality of new assembly with Merqury
+        channel.of("Step_1/01_QV")
+          | combine(merylDB_ch)
+          | combine(asm_arrow_ch)
+          | MerquryQV_01
+        channel.of("Step_1/01_bbstat")
+          | combine(asm_arrow_ch)
+          | bbstat_01
+      } else {
+        asm_arrow_ch = assembly_ch
+      }
 
-      
-      }}else if(params.paternal_assembly) {
-      // Paternal version goes here
-      tmp_ch = asm_arrow_ch.first() | SPLIT_FILE_02p |
-        map {n -> n.get(0) }
-      channel.of("Step_1/02_Purge_Dups_pat") |
-        combine(tmp_ch) |
-        combine(pacfasta_ch) |
-        PURGE_DUPS_TRIOp       // <= swap this for PURGE_DUPS_TRIO
-  
-      /* BUSCO check will go here */
-      PURGE_DUPS_TRIOp.out | map {n -> [n.get(0)] } | flatMap | 
-      combine(channel.of("Step_1/02_BUSCO_pat")) | map {n -> [n.get(1), n.get(0)]} |
-      combine(channel.of("Step_1/02_BUSCO_pat")) | map {n -> [n.get(1), n.get(0)]} |
-      BUSCO
+      pacbio_fasta_ch = pacbio_reads_ch
+        | bam_to_fasta
+        | collect
+        | map {n -> [n]}
 
-      // Maternal version 
-      tmpm_ch = asm_arrow_ch.last() | SPLIT_FILE_02m |
-        map {n -> n.get(0) }
-      channel.of("Step_1/02_Purge_Dups_mat") |
-        combine(tmpm_ch) |
-        combine(pacfasta_ch) |
-        PURGE_DUPS_TRIOm       // <= swap this for PURGE_DUPS_TRIO
-  
-      /* BUSCO check will go here */
-      PURGE_DUPS_TRIOm.out | map {n -> [n.get(0)] } | flatMap | 
-      combine(channel.of("Step_1/02_BUSCO_mat")) | map {n -> [n.get(1), n.get(0)]} |
-      BUSCO_mat
+      if ( params.primary_assembly ) {
+	      // Case 1 - primary and mito assembly, no alternate.
+	      if ( !params.alternate_assembly ) {
+            tmp_ch = channel.of("Step_1/01_ArrowPolish")
+              | combine(asm_arrow_ch)
+              | SPLIT_FILE_CASE1
+              | map {n -> [n.get(0)] }
+
+            channel.of("Step_1/02_Purge_Dups")
+              | combine(tmp_ch)
+              | combine(pacbio_fasta_ch)
+              | PURGE_DUPS_CASE1
+
+            PURGE_DUPS_CASE1.out
+              | map {n -> [n.get(0), n.get(1)] }
+              | flatMap
+              | combine(channel.of("Step_1/02_BUSCO"))
+              | map {n -> [n.get(1), n.get(0)]}
+              | BUSCO_CASE1
+	      }
+
+	      if ( params.alternate_assembly ) {
+	        tmp_ch = channel.of("Step_1/01_ArrowPolish")
+            | combine(asm_arrow_ch)
+            | SPLIT_FILE_02
+            | map {n -> [n.get(0), n.get(1)] }
+          channel.of("Step_1/02_Purge_Dups")
+            | combine(tmp_ch)
+            | combine(pacbio_fasta_ch)
+            | PURGE_DUPS_02
+
+          PURGE_DUPS_02.out
+            | map {n -> [n.get(0), n.get(1)] }
+            | flatMap
+            | combine(channel.of("Step_1/02_BUSCO"))
+            | map {n -> [n.get(1), n.get(0)]}
+            | BUSCO
+
+        }
+
+      } else if ( params.paternal_assembly ) {
+        // Paternal version
+        tmp_ch = asm_arrow_ch.first()
+          | SPLIT_FILE_02p
+          | map {n -> n.get(0) }
+        channel.of("Step_1/02_Purge_Dups_pat")
+          | combine(tmp_ch)
+          | combine(pacbio_fasta_ch)
+          | PURGE_DUPS_TRIOp
+
+        PURGE_DUPS_TRIOp.out
+          | map {n -> [n.get(0)] }
+          | flatMap
+          | combine(channel.of("Step_1/02_BUSCO_pat"))
+          | map {n -> [n.get(1), n.get(0)]}
+          | combine(channel.of("Step_1/02_BUSCO_pat"))
+          | map {n -> [n.get(1), n.get(0)]}
+          | BUSCO
+
+        // Maternal version
+        tmpm_ch = asm_arrow_ch.last()
+          | SPLIT_FILE_02m
+          | map {n -> n.get(0) }
+        channel.of("Step_1/02_Purge_Dups_mat")
+          | combine(tmpm_ch)
+          | combine(pacbio_fasta_ch)
+          | PURGE_DUPS_TRIOm
+
+        PURGE_DUPS_TRIOm.out
+          | map {n -> [n.get(0)] }
+          | flatMap
+          | combine(channel.of("Step_1/02_BUSCO_mat"))
+          | map {n -> [n.get(1), n.get(0)]}
+          | BUSCO_mat
+      }
+    } else {
+      asm_arrow_ch = assembly_ch
+
+      // Step 4: Arrow Polish with PacBio reads
+      if ( params.primary_assembly ) {
+        asm_arrow2_ch = ARROW_04(channel.of("Step_2/04_ArrowPolish"), asm_arrow_ch, pacbio_all_ch, peak_ch, merylDB_ch)
+      } else if ( params.paternal_assembly ) {
+        asm_arrow2_pat_ch = ARROW_04(channel.of("Step_2/04_ArrowPolish_pat"), asm_arrow_ch.first() , pacbio_all_ch, peak_ch, merylDB_ch)
+        asm_arrow2_mat_ch = ARROW_04b(channel.of("Step_2/04_ArrowPolish_mat"), asm_arrow_ch.last(), pacbio_all_ch, peak_ch, merylDB_ch)
+        asm_arrow2_ch = asm_arrow2_pat_ch
+          | concat(asm_arrow2_mat_ch)
+      }
+      // Step 5: Check quality of new assembly with Merqury
+      channel.of("Step_2/04_QV")
+        | combine(merylDB_ch)
+        | combine(asm_arrow2_ch)
+        | MerquryQV_04
+      channel.of("Step_2/04_bbstat")
+        | combine(asm_arrow2_ch)
+        | bbstat_04
+
+      // Step 6: FreeBayes polish with Illumina reads
+      if ( params.primary_assembly ) {
+        asm_freebayes_ch = FREEBAYES_05(channel.of("Step_2/05_FreeBayesPolish"), asm_arrow2_ch, illumina_reads_ch, peak_ch, merylDB_ch)
+      } else if ( params.paternal_assembly ) {
+        asm_freebayes_pat_ch = FREEBAYES_05(channel.of("Step_2/05_FreeBayesPolish_pat"), asm_arrow2_ch.first(), illumina_reads_ch, peak_ch, merylDB_ch)
+        asm_freebayes_mat_ch = FREEBAYES_05b(channel.of("Step_2/05_FreeBayesPolish_mat"), asm_arrow2_ch.last(), illumina_reads_ch, peak_ch, merylDB_ch)
+        asm_freebayes_ch = asm_freebayes_pat_ch
+          | concat(asm_freebayes_mat_ch )
+      }
+
+      channel.of("Step_2/05_QV")
+        | combine(merylDB_ch)
+        | combine(asm_freebayes_ch)
+        | MerquryQV_05
+      channel.of("Step_2/05_bbstat")
+        | combine(asm_freebayes_ch)
+        | bbstat_05
+
+      // Step 8: FreeBayes polish with Illumina reads
+      if ( params.primary_assembly ) {
+        asm_freebayes2_ch = FREEBAYES_06(channel.of("Step_2/06_FreeBayesPolish"), asm_freebayes_ch, illumina_reads_ch, peak_ch, merylDB_ch)
+      } else if ( params.paternal_assembly ) {
+        asm_freebayes2_pat_ch = FREEBAYES_06(channel.of("Step_2/06_FreeBayesPolish_pat"), asm_freebayes_ch.first(), illumina_reads_ch, peak_ch, merylDB_ch)
+        asm_freebayes2_mat_ch = FREEBAYES_06b(channel.of("Step_2/06_FreeBayesPolish_mat"), asm_freebayes_ch.last(), illumina_reads_ch, peak_ch, merylDB_ch)
+        asm_freebayes2_ch = asm_freebayes2_pat_ch
+          | concat(asm_freebayes2_mat_ch)
+      }
+
+      channel.of("Step_2/06_QV")
+        | combine(merylDB_ch)
+        | combine(asm_freebayes2_ch)
+        | MerquryQV_06
+      channel.of("Step_2/06_bbstat")
+        | combine(asm_freebayes2_ch)
+        | bbstat_06
+
+      if (params.primary_assembly) {
+        channel.of("Step_2/06_FreeBayesPolish")
+          | combine(asm_freebayes2_ch)
+          | SPLIT_FILE_07
+      } else if ( params.paternal_assembly ) {
+        asm_freebayes2_ch.first()
+          | SPLIT_FILE_07p
+        asm_freebayes2_ch.last()
+          | SPLIT_FILE_07m
+      }
     }
-  } else {
-    asm_arrow_ch = asm_ch
-
-    // Step 4: Arrow Polish with PacBio reads
-    if(params.primary_assembly){
-      asm_arrow2_ch = ARROW_04(channel.of("Step_2/04_ArrowPolish"), asm_arrow_ch, pacall_ch, peak_ch, merylDB_ch)
-    } else if (params.paternal_assembly) {
-      asm_arrow2p_ch = ARROW_04(channel.of("Step_2/04_ArrowPolish_pat"), asm_arrow_ch.first() , pacall_ch, peak_ch, merylDB_ch)
-      asm_arrow2m_ch = ARROW_04b(channel.of("Step_2/04_ArrowPolish_mat"), asm_arrow_ch.last(), pacall_ch, peak_ch, merylDB_ch)
-      asm_arrow2_ch = asm_arrow2p_ch | concat(asm_arrow2m_ch)
-    }
-    // Step 5: Check quality of new assembly with Merqury 
-    channel.of("Step_2/04_QV") | combine(merylDB_ch) | combine(asm_arrow2_ch) | MerquryQV_04
-    channel.of("Step_2/04_bbstat") | combine(asm_arrow2_ch) | bbstat_04
-
-    // Step 6: FreeBayes Polish with Illumina reads
-    if(params.primary_assembly){
-      asm_freebayes_ch = FREEBAYES_05(channel.of("Step_2/05_FreeBayesPolish"), asm_arrow2_ch, ill_ch, peak_ch, merylDB_ch)
-    }else if(params.paternal_assembly){
-      asm_freebayesp_ch = FREEBAYES_05(channel.of("Step_2/05_FreeBayesPolish_pat"), asm_arrow2_ch.first(), ill_ch, peak_ch, merylDB_ch)
-      asm_freebayesm_ch = FREEBAYES_05b(channel.of("Step_2/05_FreeBayesPolish_mat"), asm_arrow2_ch.last(), ill_ch, peak_ch, merylDB_ch)
-      asm_freebayes_ch = asm_freebayesp_ch | concat(asm_freebayesm_ch )
-    }
-    
-    channel.of("Step_2/05_QV") | combine(merylDB_ch) | combine(asm_freebayes_ch) | MerquryQV_05
-    channel.of("Step_2/05_bbstat") | combine(asm_freebayes_ch) | bbstat_05
- 
-    // Step 8: FreeBayes Polish with Illumina reads
-    if(params.primary_assembly){
-      asm_freebayes2_ch = FREEBAYES_06(channel.of("Step_2/06_FreeBayesPolish"), asm_freebayes_ch, ill_ch, peak_ch, merylDB_ch)
-    } else if (params.paternal_assembly) {
-      asm_freebayes2p_ch = FREEBAYES_06(channel.of("Step_2/06_FreeBayesPolish_pat"), asm_freebayes_ch.first(), ill_ch, peak_ch, merylDB_ch)
-      asm_freebayes2m_ch = FREEBAYES_06b(channel.of("Step_2/06_FreeBayesPolish_mat"), asm_freebayes_ch.last(), ill_ch, peak_ch, merylDB_ch)
-      asm_freebayes2_ch = asm_freebayes2p_ch | concat(asm_freebayes2m_ch)
-    }
-    
-    channel.of("Step_2/06_QV") | combine(merylDB_ch) | combine(asm_freebayes2_ch) | MerquryQV_06
-    channel.of("Step_2/06_bbstat") | combine(asm_freebayes2_ch) | bbstat_06
-
-    if(params.primary_assembly){
-      channel.of("Step_2/06_FreeBayesPolish") | combine(asm_freebayes2_ch) | SPLIT_FILE_07
-    } else if (params.paternal_assembly) {
-      asm_freebayes2_ch.first() | SPLIT_FILE_07p
-      asm_freebayes2_ch.last() | SPLIT_FILE_07m
-    }
-  }
   }
 }
 

--- a/modules/arrow.nf
+++ b/modules/arrow.nf
@@ -2,7 +2,11 @@
 
 nextflow.enable.dsl=2
 
-include { create_windows; combineVCF; meryl_genome; merfin_polish; vcf_to_fasta } from './helper_functions.nf'
+include { create_windows;
+          combineVCF;
+          meryl_genome;
+          merfin_polish;
+          vcf_to_fasta } from './helper_functions.nf'
 
 process pbmm2_index {
   publishDir "${params.outdir}/${outdir}", mode: 'symlink'
@@ -95,15 +99,28 @@ workflow ARROW {
     asm_ch
     pac_ch
   main:
-    win_ch = outdir_ch | combine(asm_ch) | create_windows | 
-      map { n -> n.get(1) } | splitText() {it.trim() }
-    fai_ch = create_windows.out | map { n -> n.get(0) }
+    win_ch = outdir_ch
+      | combine(asm_ch)
+      | create_windows
+      | map { n -> n.get(1) }
+      | splitText() {it.trim() }
 
-    newasm_ch = outdir_ch | combine(asm_ch) | pbmm2_index | combine(pac_ch) | pbmm2_align |
-      combine(asm_ch) | combine(fai_ch) | combine(win_ch) | gcpp_arrow | 
-      map { n -> [ n.get(0), n.get(1) ] } | groupTuple | 
-      merge_consensus
-  
+    fai_ch = create_windows.out
+      | map { n -> n.get(0) }
+
+    newasm_ch = outdir_ch
+      | combine(asm_ch)
+      | pbmm2_index
+      | combine(pac_ch)
+      | pbmm2_align
+      | combine(asm_ch)
+      | combine(fai_ch)
+      | combine(win_ch)
+      | gcpp_arrow
+      | map { n -> [ n.get(0), n.get(1) ] }
+      | groupTuple
+      | merge_consensus
+
   emit:
     newasm_ch
 }
@@ -130,28 +147,54 @@ workflow ARROW_MERFIN {
     pac_ch
     peak_ch
     merylDB_ch
-    
+
   main:
+    win_ch = outdir_ch
+      | combine(asm_ch)
+      | create_windows
+      | map { n -> n.get(1) }
+      | splitText() {it.trim() }
 
-    win_ch = outdir_ch | combine(asm_ch) | create_windows | 
-      map { n -> n.get(1) } | splitText() {it.trim() } 
-    fai_ch = create_windows.out | map { n -> n.get(0) } 
+    fai_ch = create_windows.out
+      | map { n -> n.get(0) }
 
-    arrow_run_ch = outdir_ch | combine(asm_ch) | pbmm2_index | combine(pac_ch) | pbmm2_align |
-      combine(asm_ch) | combine(fai_ch) | combine(win_ch) | gcpp_arrow 
-    if (params.same_specimen) {
+    arrow_run_ch = outdir_ch
+      | combine(asm_ch)
+      | pbmm2_index
+      | combine(pac_ch)
+      | pbmm2_align
+      | combine(asm_ch)
+      | combine(fai_ch)
+      | combine(win_ch)
+      | gcpp_arrow
+
+    if ( params.same_specimen ) {
       /* create a genome meryl db */
-      asm_meryl = outdir_ch | combine(channel.of(params.k)) | combine(asm_ch) | meryl_genome 
+      asm_meryl = outdir_ch
+        | combine(channel.of(params.k))
+        | combine(asm_ch)
+        | meryl_genome
 
       /* prepare and run merfin polish */
-      newasm_ch = arrow_run_ch | map { n -> [ n.get(0), n.get(2) ] } | groupTuple |
-        combineVCF | reshape_arrow | combine(asm_ch) |  combine(asm_meryl) |combine(peak_ch) |
-        combine(merylDB_ch) | merfin_polish | combine(asm_ch) | vcf_to_fasta
+      newasm_ch = arrow_run_ch
+        | map { n -> [ n.get(0), n.get(2) ] }
+        | groupTuple
+        | combineVCF
+        | reshape_arrow
+        | combine(asm_ch)
+        | combine(asm_meryl)
+        | combine(peak_ch)
+        | combine(merylDB_ch)
+        | merfin_polish
+        | combine(asm_ch)
+        | vcf_to_fasta
     } else {
-      newasm_ch = arrow_run_ch | map { n -> [ n.get(0), n.get(1) ] } | groupTuple |
-        merge_consensus
+      newasm_ch = arrow_run_ch
+        | map { n -> [ n.get(0), n.get(1) ] }
+        | groupTuple
+        | merge_consensus
     }
-  
+
   emit:
     newasm_ch
 }

--- a/modules/busco.nf
+++ b/modules/busco.nf
@@ -5,7 +5,7 @@ nextflow.enable.dsl=2
 // process BUSCO_setup {
 //   publishDir "${params.outdir}/03c_BUSCO", mode: 'copy'
 //   output:tuple path("config"), path("Busco_version.txt")
-// 
+//
 //   script:
 //   """
 //   #! /usr/bin/env bash
@@ -20,25 +20,25 @@ process BUSCO {
 
   input: tuple val(outdir), path(genomeFile)
   output: path("${genomeFile.simpleName}/*")
-  
+
   script:
   """
   #! /usr/bin/env bash
   PROC=\$((`nproc`))
- 
-  if [ -s ${genomeFile} ]; then  
- 
+
+  if [ -s ${genomeFile} ]; then
+
   cat ${genomeFile} | tr '|' '_' > ${genomeFile.simpleName}_fixheaders.fna
 
   ${busco_app} \
     -o ${genomeFile.simpleName} \
     -i ${genomeFile.simpleName}_fixheaders.fna \
     ${busco_params} \
-    -c \${PROC} 
+    -c \${PROC}
 
-else 
+else
   mkdir ${genomeFile.simpleName}
-  echo '${genomeFile.simpleName} is empty, this is a stub' > ${genomeFile.simpleName}/empty.txt 
+  echo '${genomeFile.simpleName} is empty, this is a stub' > ${genomeFile.simpleName}/empty.txt
 
 fi
   """

--- a/modules/helper_functions.nf
+++ b/modules/helper_functions.nf
@@ -32,13 +32,13 @@ process MERGE_FILE {
   #! /usr/bin/env bash
 
   # === Inputs
-  # primary_assembly = p_ctg.fasta     # From FALCON or FALCON-Unzip 
+  # primary_assembly = p_ctg.fasta     # From FALCON or FALCON-Unzip
   # alternate_assembly = a_ctg.fasta
   # mito_assembly = mt.fasta           # From vgpMito pipeline
-  
+
   # === Outputs
   # ${primary_assembly.simpleName}_merged.fasta
-  
+
   cat ${primary_assembly} | sed 's/>/>pri_/g' > ${primary_assembly.simpleName}_temp.fasta
   echo "" >> ${primary_assembly.simpleName}_temp.fasta
   cat ${mito_assembly} | sed 's/>/>mit_/g' >> ${primary_assembly.simpleName}_temp.fasta
@@ -61,14 +61,14 @@ process MERGE_FILE_TRIO {
   script:
   """
   #! /usr/bin/env bash
-  
+
   # === Inputs
   # primary_assembly = p_ctg.fasta     # From Canu, maternal or paternal
   # mito_assembly = mt.fasta           # From vgpMito pipeline
-  
+
   # === Outputs
   # ${primary_assembly.simpleName}_merged.fasta
-  
+
   cat ${primary_assembly} | sed 's/>/>pri_/g' > ${primary_assembly.simpleName}_temp.fasta
   echo "" >> ${primary_assembly.simpleName}_temp.fasta
   cat ${mito_assembly} | sed 's/>/>mit_/g' >> ${primary_assembly.simpleName}_temp.fasta
@@ -90,14 +90,14 @@ process MERGE_FILE_CASE1 {
   script:
   """
   #! /usr/bin/env bash
-  
+
   # === Inputs
   # primary_assembly = p_ctg.fasta     # From CANU, similar to Falcon but without alternative assembly
   # mito_assembly = mt.fasta           # From vgpMito pipeline
-  
+
   # === Outputs
   # ${primary_assembly.simpleName}_merged.fasta
-  
+
   cat ${primary_assembly} | sed 's/>/>pri_/g' > ${primary_assembly.simpleName}_temp.fasta
   echo "" >> ${primary_assembly.simpleName}_temp.fasta
   cat ${mito_assembly} | sed 's/>/>mit_/g' >> ${primary_assembly.simpleName}_temp.fasta
@@ -118,18 +118,18 @@ process SPLIT_FILE_p {
   script:
   """
   #! /usr/bin/env bash
-  
+
   # === Inputs
   # genome_fasta = primary_assembly_merged.fasta
   # === Outputs
   # p_${genome_fasta}     # primary assembly
   # a_${genome_fasta}     # alternative assembly
   # m_${genome_fasta}     # mitochondrial assembly
-  
+
   ${samtools_app} faidx ${genome_fasta}
   grep ">pri_" ${genome_fasta} | cut -f1 | sed 's/>//g' > pri.list
   ${samtools_app} faidx -r pri.list ${genome_fasta} > pat_${genome_fasta}
-  
+
   grep ">mit_" ${genome_fasta} | cut -f1 | sed 's/>//g' > mit.list
   ${samtools_app} faidx -r mit.list ${genome_fasta} > mit_${genome_fasta}
   """
@@ -147,18 +147,18 @@ process SPLIT_FILE_m {
   script:
   """
   #! /usr/bin/env bash
-  
+
   # === Inputs
   # genome_fasta = primary_assembly_merged.fasta
   # === Outputs
   # p_${genome_fasta}     # primary assembly
   # a_${genome_fasta}     # alternative assembly
   # m_${genome_fasta}     # mitochondrial assembly
-  
+
   ${samtools_app} faidx ${genome_fasta}
   grep ">pri_" ${genome_fasta} | cut -f1 | sed 's/>//g' > pri.list
   ${samtools_app} faidx -r pri.list ${genome_fasta} > mat_${genome_fasta}
-  
+
   grep ">mit_" ${genome_fasta} | cut -f1 | sed 's/>//g' > mit.list
   ${samtools_app} faidx -r mit.list ${genome_fasta} > mit_${genome_fasta}
   """
@@ -209,25 +209,25 @@ process SPLIT_FILE {
   script:
   """
   #! /usr/bin/env bash
-  
+
   # === Inputs
   # genome_fasta = primary_assembly_merged.fasta
   # === Outputs
   # p_${genome_fasta}     # primary assembly
   # a_${genome_fasta}     # alternative assembly
   # m_${genome_fasta}     # mitochondrial assembly
-  
+
   ${samtools_app} faidx ${genome_fasta}
   grep ">pri_" ${genome_fasta} | cut -f1 | sed 's/>//g' > pri.list
   ${samtools_app} faidx -r pri.list ${genome_fasta} > p_${genome_fasta}
-  
+
   grep ">mit_" ${genome_fasta} | cut -f1 | sed 's/>//g' > mit.list
   ${samtools_app} faidx -r mit.list ${genome_fasta} > m_${genome_fasta}
-  
+
   grep ">alt_" ${genome_fasta} | cut -f1 | sed 's/>//g' > alt.list
   ${samtools_app} faidx -r alt.list ${genome_fasta} > a_${genome_fasta}
   """
-  
+
   stub:
   """
   touch p_${genome_fasta} a_${genome_fasta} m_${genome_fasta}
@@ -236,7 +236,7 @@ process SPLIT_FILE {
 
 process RENAME_FILE {
   publishDir "${params.outdir}/00_Preprocess/", mode:'copy'
-  
+
   input: tuple path(filename), val(newname)
   output: path("$newname")
   script:
@@ -320,9 +320,9 @@ process merfin_polish {
   script:
   """
   #! /usr/bin/env bash
-  
+
   OUTNAME=`echo $outdir | sed 's:/:_:g'`
-  
+
   ${merfin_app} -polish \
     -sequence ${genome_fasta} \
     -seqmers ${genome_meryl} \
@@ -331,9 +331,9 @@ process merfin_polish {
     -vcf ${vcf} \
     -output \${OUTNAME}_merfin \
     ${merfin_params}
-    
+
   """
-  
+
   stub:
   """
   OUTNAME=`echo $outdir | sed 's:/:_:g'`
@@ -348,9 +348,9 @@ process vcf_to_fasta {
   script:
   """
   #! /usr/bin/env bash
-  
+
   OUTNAME=`echo $outdir | sed 's:/:_:g'`
-  
+
   ${bcftools_app} view -Oz ${vcf} > ${vcf}.gz
   ${bcftools_app} index ${vcf}.gz
   ${bcftools_app} consensus ${vcf}.gz -f ${genome_fasta} -Hla > \${OUTNAME}_consensus.fasta

--- a/modules/purge_dups.nf
+++ b/modules/purge_dups.nf
@@ -5,7 +5,7 @@ nextflow.enable.dsl=2
 process PURGE_DUPS {
   publishDir "${params.outdir}/$outdir", mode:'copy'
   input: tuple val(outdir), path(primary_assembly), path(haplo_fasta), path(pacbio_reads)
-  output: tuple path("primary_purged.fa"), path("haps_purged.fa"), path("*.log") // 
+  output: tuple path("primary_purged.fa"), path("haps_purged.fa"), path("*.log") //
   script:
   template 'purge_dups.sh'
 
@@ -45,4 +45,4 @@ process PURGE_DUPS_TRIO {
   """
 }
 
- 
+

--- a/modules/qv.nf
+++ b/modules/qv.nf
@@ -45,7 +45,7 @@ process meryl_peak {
   script:
   """
   #! /usr/bin/env bash
-  
+
   # Calculate histogram
   ${meryl_app} histogram ${illumina_meryl} > illumina.hist
   awk '\$1>5 {print}' illumina.hist | sort -k 2n | tail -n 1 | awk '{print \$1}' > peak.txt

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,6 +1,5 @@
 /****************************
  * Default Parameter Values
- * nextflow run script.nf --primary_assembly "/path/to/p_ctg.fasta"
  ****************************/
 
 params {
@@ -22,12 +21,12 @@ params {
   pacbio_reads = false
   k = "21"
   species = 'species_name'
-  meryldb = false /* can pass in a prebuilt illumina meryl db file, otherwise will build */
+  meryldb = false /* Passing in a prebuilt Illumina Meryl DB file will speed up QV checks */
 
   /* Modifiers */
   falcon_unzip = false
   same_specimen = true
-  steptwo = false   /* retire this */
+  steptwo = false /* retire this */
   step = 1
 
   /* Slurm */
@@ -141,8 +140,8 @@ report {
 
 manifest {
   name = 'isugifNF/polishCLR'
-  homePage = 'www.bioinformaticsworkbook.org'
-  description = 'Nextflow implementation of Arrow and Freebayes assembly polishing'
+  homePage = 'https://github.com/isugifNF/polishCLR'
+  description = 'Nextflow implementation of Arrow and FreeBayes assembly polishing'
   mainScript = 'main.nf'
   version = '1.0.0'
 }


### PR DESCRIPTION
## Description

Cleaning up the code base for readability:

* Refactor such that imports on each module happens once, instead of split out
* Add line breaks and tabs to long piped commands
* Fix indentation in code
* Expand variable names to full words
* Fix capitalization in help messages

## Issues

Reformatting code so it's easier to work toward addressing:

* https://github.com/isugifNF/polishCLR/issues/27
* https://github.com/isugifNF/polishCLR/issues/28
* https://github.com/isugifNF/polishCLR/issues/41
* https://github.com/isugifNF/polishCLR/issues/24

## Testing

Test on the HPC, with an example dataset. Maybe something like:

```
#! /usr/bin/env bash
#SBATCH --nodes=1
#SBATCH --ntasks-per-node=4
#SBATCH --time=24:00:00
#SBATCH --job-name=polishCLR_TEST
#SBATCH --output=R-%x.%J.out
#SBATCH --error=R-%x.%J.err

# == Ceres HPC
module load nextflow
NEXTFLOW=nextflow
# module load merfin

# === Set working directory and in/out variables
cd ${SLURM_SUBMIT_DIR}

# # === Using Conda Environments if singularity doesn't run
# module load miniconda
# source activate /project/ag100pest/conda_envs/polishCLR/

# === Main Program
$NEXTFLOW run isugifNF/polishCLR -r refactor_linebreaks \
  --primary_assembly "/project/ag100pest/Pgos/RawData/3-unzip/all_p_ctg.fasta" \
  --illumina_reads "/project/ag100pest/Illumina_polishing/JAMU*{R1,R2}.fastq.bz2" \
  --pacbio_reads "/project/ag100pest/Pgos/RawData/m54334U_190823_194159.subreads.bam" \
  --k "21" \
  -profile slurm \
  -with-singularity polishCLR.sif
```