### PR TITLE
defaultBranch: changed to main

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -138,6 +138,7 @@ report {
 }
 
 manifest {
+  defaultBranch = 'main'
   name = 'isugifNF/polishCLR'
   homePage = 'https://github.com/isugifNF/polishCLR'
   description = 'Nextflow implementation of Arrow and FreeBayes assembly polishing'


### PR DESCRIPTION
# Description

Change defaultBranch from `master` to `main`. Originally we needed to use a `-r main` such as:

```
nextflow run isugifNF/polishCLR -r main \
  --help
```

But with this commit, hopefully we can use

```
nextflow run isugifNF/polishCLR \
  --help
```
